### PR TITLE
Updated to prevent inaccessible due to 'internal' protection level issues

### DIFF
--- a/Sources/Nanoid.swift
+++ b/Sources/Nanoid.swift
@@ -9,11 +9,13 @@
 import Foundation
 
 public class Nanoid {
-    var randomizer: RandomSource = URandom()
-    var alphabet: Alphabet = .alphameric
-    var length = 32
+    public var randomizer: RandomSource = URandom()
+    public var alphabet: Alphabet = .alphameric
+    public var length = 32
 
-    var secureToken: String {
+    public init() {}
+    
+    public var secureToken: String {
         let randomBytes = randomizer.get(numBytes: length)
         let randomCharacters = randomBytes.map { byte -> Character in
             return self.alphabet.character(for: byte)


### PR DESCRIPTION
This library as it stands runs into the Swift `'secureToken' is inaccessible due to 'internal' protection level.' It needed `public init() {}` added as well as 'public' to each of the public variables to match the documentation. 

Any chance you can update the Pod? 